### PR TITLE
Update package.yaml

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -30,7 +30,6 @@ dependencies:
 
 library:
   source-dirs: src
-  dependencies:
   exposed-modules:
     - Hpack.Convert
 


### PR DESCRIPTION
When using stack install, the library field is causing this error Error while parsing $.library.dependencies - expected Array, Object, or String, encountered Null