### PR TITLE
Fcontext stack deprecated

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -30,7 +30,6 @@ dependencies:
 
 library:
   source-dirs: src
-  dependencies:
   exposed-modules:
     - Hpack.Convert
 

--- a/package.yaml
+++ b/package.yaml
@@ -6,7 +6,7 @@ license: MIT
 github: yamadapc/hpack-convert
 category: Development
 
-ghc-options: -Wall -fcontext-stack=100
+ghc-options: -Wall -freduction-depth=100
 extra-source-files:
   - ./test/data/**/*
 


### PR DESCRIPTION
Building executable 'hpack-convert' for hpack-convert-1.0.1..

on the commandline: error: [-Werror]
    -fcontext-stack=100 is deprecated: use -freduction-depth=100 instead

--  While building package hpack-convert-1.0.1 using:
      /Users/williamrusnack/.stack/setup-exe-cache/x86_64-osx/Cabal-simple_mPHDZzAJ_3.0.1.0_ghc-8.8.2 --builddir=.stack-work/dist/x86_64-osx/Cabal-3.0.1.0 build lib:hpack-convert exe:hpack-convert --ghc-options " -fdiagnostics-color=always"
    Process exited with code: ExitFailure 1